### PR TITLE
Fixed wrong strip cover length

### DIFF
--- a/Icosahedron/Icosaeder.scad
+++ b/Icosahedron/Icosaeder.scad
@@ -109,7 +109,7 @@ module stripCover() {
         translate([-(12+2*wallThickness)/2,-4,0]) cube([12+2*wallThickness, wallSide+wallThickness, triangleLength+wallOffset+cornerTriangle*2]);
         translate([-12/2,-3.5,0]) cube([12, wallSide, triangleLength+wallOffset+cornerTriangle*2]);
         translate([0,0,0]) corner(); // for end
-        translate([0,0,triangleLength+wallOffset+cornerTriangle*2]) mirror([0,0,1]) corner(); // for end
+        translate([0,0,triangleLength+wallOffset]) mirror([0,0,1]) corner(); // for end
     }
 }
 


### PR DESCRIPTION
**At first: Thanks for the SCAD files! I've built this cube and I really appreciate your work on the SCAD files.**

I've found and fixed a bug in the Icosaeder.scad file that results in an strip cover that is too long for the connector.

I've printed both versions (the buggy and the fixed one). The Buggy was clearly too long and wouldn't fit on the Icosahedron. But the fixed one worked like a charm.

## Comparison

Original SCAD (with bug) | New SCAD (without bug)
--------------------------------- | ----------------------------------
![StripCover_buggy_with-connector](https://user-images.githubusercontent.com/5895949/71322073-5e726780-24c3-11ea-9e4b-81f5d3485218.png)  |  ![StripCover_fixed_with-connector](https://user-images.githubusercontent.com/5895949/71322074-5e726780-24c3-11ea-95fe-c214cee8a0c4.png)
![StripCover_buggy_without-connector](https://user-images.githubusercontent.com/5895949/71322088-9e394f00-24c3-11ea-867a-3460c0bc262c.png)  |  ![StripCover_fixed_without-connector](https://user-images.githubusercontent.com/5895949/71322089-9e394f00-24c3-11ea-8fbf-7df36ba63cc8.png)


